### PR TITLE
plugins/wdc: fix json output for vs-nand-stats

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10835,13 +10835,13 @@ static void wdc_print_nand_stats_json(__u16 version, void *data)
 				le32_to_cpu(nand_stats_v3->ssd_correction_counts[12]));
 		json_object_add_value_uint(root, "System data % life-used",
 				nand_stats_v3->percent_life_used);
-		json_object_add_value_uint64(root, "User Data Erase Counts - SLC Min",
-				le64_to_cpu(nand_stats_v3->user_data_erase_counts[0]));
-		json_object_add_value_uint64(root, "User Data Erase Counts - SLC Max",
-				le64_to_cpu(nand_stats_v3->user_data_erase_counts[1]));
 		json_object_add_value_uint64(root, "User Data Erase Counts - TLC Min",
-				le64_to_cpu(nand_stats_v3->user_data_erase_counts[2]));
+				le64_to_cpu(nand_stats_v3->user_data_erase_counts[0]));
 		json_object_add_value_uint64(root, "User Data Erase Counts - TLC Max",
+				le64_to_cpu(nand_stats_v3->user_data_erase_counts[1]));
+		json_object_add_value_uint64(root, "User Data Erase Counts - SLC Min",
+				le64_to_cpu(nand_stats_v3->user_data_erase_counts[2]));
+		json_object_add_value_uint64(root, "User Data Erase Counts - SLC Max",
 				le64_to_cpu(nand_stats_v3->user_data_erase_counts[3]));
 		temp_ptr = (__u64 *)nand_stats_v3->program_fail_count;
 		temp_norm = (__u16)(*temp_ptr & 0x000000000000FFFF);


### PR DESCRIPTION

Running nvme wdc vs-nand-stats will change the values of the user data fields 
depending on output format used.  In regular stdout, the ordering is TLC min, 
TLC Max, SLC Min, SLC Max.  However in json, the values get reassigned, what 
was SLC Min in stdout will become TLC >

Regular format (TLC Min, TLC Max, SLC Min, SLC Max)
  [root@ /tmp/]# nvme wdc vs-nand-stats /dev/nvme0n1  | grep User\ Data
    User Data Erase Counts - TLC Min               169
    User Data Erase Counts - TLC Max               310
    User Data Erase Counts - SLC Min               10719
    User Data Erase Counts - SLC Max               11676

Json format (SLC Min, SLC Max, TLC Min, TLC Max)
  [root@ /tmp/]# nvme wdc vs-nand-stats /dev/nvme0n1 -o json | grep User\ Data
    "User Data Erase Counts - SLC Min" : 169,
    "User Data Erase Counts - SLC Max" : 310,
    "User Data Erase Counts - TLC Min" : 10719,
    "User Data Erase Counts - TLC Max" : 11676,



The difference can be traced to how the array subscripts are being 
used in the two output formats

stdout : https://t.ly/sRIDz

tlc_min == 0
tlc_max == 1
slc_min == 2
slc_max == 3

json : https://t.ly/pmU-m
slc_min = 0
slc_max = 1
tlc_min = 2
tlc_max = 3


With the patch, we rename the fields to be the same for both stdout & json.
Output comparison below


Regular format (TLC Min, TLC Max, SLC Min, SLC Max)
 [root@ /tmp/]# ./nvme wdc vs-nand-stats /dev/nvme0n1 | grep User\ Data
   User Data Erase Counts - TLC Min               169
   User Data Erase Counts - TLC Max               310
   User Data Erase Counts - SLC Min               10719
   User Data Erase Counts - SLC Max               11676

Json format (TLC Min, TLC Max, SLC Min, SLC Max)
 [root@ /tmp/]# ./nvme wdc vs-nand-stats /dev/nvme0n1 -o json | grep User\ Data
   "User Data Erase Counts - TLC Min":169,
   "User Data Erase Counts - TLC Max":310,
   "User Data Erase Counts - SLC Min":10719,
   "User Data Erase Counts - SLC Max":11676,


Signed-off-by: Carl Moran <carl.moran1@meta.com>
